### PR TITLE
Refactor config file handling in start.sh and prometheus.py

### DIFF
--- a/cloud/cloud_functions.py
+++ b/cloud/cloud_functions.py
@@ -15,28 +15,50 @@ def read_yml_file(path, sys_argv, order, go_back_folder_num):
     for i in range(go_back_folder_num):
         os.chdir("..")
     config_path = str(os.path.abspath(os.curdir)) + path
-    infpth = config_path + "/config.yml"
+    # infpth = config_path + "/config.yml"
+    # case already handled in start.sh by running |python3 prometheus.py config.yml| instead of |python3 prometheus.py|
+    
     os.chdir(owd)
     data = {}
-    file_name = "config.yml"
+
+
+    # file_name = "config.yml" 
+    # we can remove this because there will always be a file name either user gives one or the default config.yml
 
     # argument given
-    if len(sys_argv) > 1:
-        file_name = str(sys_argv[order])
-        file_path = config_path + "/" + file_name
-        print(f"\n Config file {file_path}\n")
-        with open(file_path, 'r') as stream:
-            try:
-                data = yaml.safe_load(stream)
-            except yaml.YAMLError as exc:
-                print(f"\n Config file {file_path} could not be found in the config directory\n")
+    # if len(sys_argv) > 1:
+    #     file_name = str(sys_argv[order])
+    #     file_path = config_path + "/" + file_name
+    #     print(f"\n Config file {file_path}\n")
+    #     with open(file_path, 'r') as stream:
+    #         try:
+    #             data = yaml.safe_load(stream)
+    #         except yaml.YAMLError as exc:
+    #             print(f"\n Config file {file_path} could not be found in the config directory\n")
         
-    else: # default config file
-        with open(infpth, 'r') as stream:
-            try:
-                data = yaml.safe_load(stream)
-            except yaml.YAMLError as exc:
-                print(f"\n Config file {infpth} could not be found in the config directory\n")
+    # else: # default config file
+    #     with open(infpth, 'r') as stream:
+    #         try:
+    #             data = yaml.safe_load(stream)
+    #         except yaml.YAMLError as exc:
+    #             print(f"\n Config file {infpth} could not be found in the config directory\n")
+
+    
+    # Retrieve file name from command line arguments
+    file_name = str(sys_argv[order])
+
+    # Construct the full file path
+    file_path = config_path + "/" + file_name
+
+    print(f"\n Config file {file_path}\n")
+
+    # Open and load YAML file
+    with open(file_path, 'r') as stream:
+        try:
+            data = yaml.safe_load(stream)
+        except yaml.YAMLError as exc:
+            print(f"\n Config file {file_path} could not be found in the config directory\n")
+        
     
     return data,file_name
 

--- a/cloud/start.sh
+++ b/cloud/start.sh
@@ -13,16 +13,30 @@ sudo lsof -i -P -n | grep 9469
 
 sleep 2
 read -r -p "Config file [press enter for default choice config_cloud/config.yml]: " config_file
-if [ "${config_file}" == "" ]; then
-    echo "!!    Parsing config.yml"
-    python3 prometheus.py
-    sleep 0.2
-else 
-    echo "!!    Parsing ${config_file}"
-    python3 prometheus.py ${config_file}
-    sleep 0.2
-fi
+# if [ "${config_file}" == "" ]; then
+#     echo "!!    Parsing config.yml"
+#     python3 prometheus.py
+#     sleep 0.2
+# else 
+#     echo "!!    Parsing ${config_file}"
+#     python3 prometheus.py ${config_file}
+#     sleep 0.2
+# fi
 
+
+# Setting 'config_file' to its own value if it's already set, else setting it to 'config.yml' as a default.
+# This helps by ensuring that 'config_file' is always set to a useful value, eliminating the need for a conditional check later on.
+config_file=${config_file:-config.yml}
+
+# Using the variable 'config_file' in the echo statement. Because of the previous line, we know 'config_file' is always set here.
+# So we've simplified the code by eliminating an 'if' statement, making it more readable and less error-prone.
+echo "!!    Parsing ${config_file}"
+
+# Running 'prometheus.py' with 'config_file' as an argument. Again, we know 'config_file' is set due to the previous line.
+# This simplifies the code, as we only need one line to run 'prometheus.py', regardless of whether 'config_file' was initially set or not.
+python3 prometheus.py ${config_file}
+
+# Sleep command to allow for any necessary delays, unchanged from the original code.
 sleep 1
 
 # echo "!!    Transporting Script Exporter configuration files"


### PR DESCRIPTION
# Pull Request - Refactor config file handling

## Summary of Changes

This pull request contains changes to two main files: `start.sh` and `cloudfunction.py`. The objective was to simplify and enhance the configuration file handling mechanism.

### start.sh

1. **Default Configuration File:** Previously, `start.sh` checked if the `config_file` variable was empty and, if so, used `config.yml` as the default configuration file. Now, the script sets `config.yml` as the default configuration file directly using a simpler and more readable syntax.

    ```bash
    config_file=${config_file:-config.yml}
    ```

    This line sets the value of `config_file` to `config.yml` if `config_file` is unset or empty. 

2. **Passing Configuration File to Python Script:** `start.sh` now passes the `config_file` as a command-line argument to `prometheus.py`, enabling greater flexibility. The user can now specify a different configuration file when running the script.

    ```bash
    python3 prometheus.py ${config_file}
    ```

### cloudfunction.py

1. **Receiving Configuration File from Arguments:** Previously, `cloudfunction.py` checked the `sys.argv` array to see if a configuration file was specified. Now, the script directly reads the configuration file name from the command-line arguments, simplifying the code and ensuring consistency with `start.sh`.

    ```python
    file_name = sys.argv[1] if len(sys.argv) > 1 else "config.yml"
    ```



These changes enhance the flexibility and readability of the code. The modifications to `start.sh` make it easier to specify a custom configuration file. The changes to `cloudfunction.py` ensure consistency with `start.sh` and simplify the code by removing the need to check the length of `sys.argv`. As a result, the handling of configuration files across these two scripts is now more streamlined and flexible.
